### PR TITLE
chore: don't pack `test/` folder and other dev files

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,9 @@
 	},
 	"publishConfig": {
 		"ignore": [
-			".github/workflows"
+			".eslintrc",
+			".github/workflows",
+			"test"
 		]
 	}
 }


### PR DESCRIPTION
currently this package includes a bunch of dev/test files

![image](https://github.com/ljharb/jsonify/assets/83948/53168402-fedc-446f-9868-e2800e24bdad)

## Test Plan

run `npm pack`. You should see only these files listed in tarball contents
```
npm notice === Tarball Contents === 
npm notice 578B  .github/FUNDING.yml
npm notice 4.5kB CHANGELOG.md       
npm notice 2.5kB README.md          
npm notice 103B  index.js           
npm notice 4.6kB lib/parse.js       
npm notice 4.3kB lib/stringify.js   
npm notice 1.6kB package.json   
```