### PR TITLE
[fix] parse: fix reviver not recursing into nested objects

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -245,7 +245,7 @@ module.exports = function (source, reviver) {
 		var v;
 		var val = holder[key];
 		if (val && typeof val === 'object') {
-			for (k in value) {
+			for (k in val) {
 				if (Object.prototype.hasOwnProperty.call(val, k)) {
 					v = walk(val, k);
 					if (typeof v === 'undefined') {

--- a/test/parse.js
+++ b/test/parse.js
@@ -18,3 +18,21 @@ test('parse', function (t) {
 
 	t.end();
 });
+
+test('parse with reviver', function (t) {
+	var data = '{"a": {"b": 2}}';
+	var calls = [];
+
+	json.parse(data, function reviver(key, value) {
+		calls[calls.length] = key;
+		return value;
+	});
+
+	t.deepEqual(
+		calls.sort(),
+		['', 'a', 'b'].sort(),
+		'reviver is called for all nested properties'
+	);
+
+	t.end();
+});


### PR DESCRIPTION
The walk function in the reviver implementation was iterating over the
'value' function instead of 'val' (the current object node). This prevented
the reviver from being called for nested properties.

Changed: for (k in value) to for (k in val)

This ensures the reviver function is properly called for all nested objects
and arrays, matching the behavior of native JSON.parse.